### PR TITLE
Makefile: Allow to specify ATF binary path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,12 @@ $(BUILDDIR)/fip/gxl/bl30_new.bin: fip
 $(BUILDDIR)/fip/gxl/bl30.bin.enc: $(BUILDDIR)/fip/gxl/bl30_new.bin $(PROG)
 	./$(PROG) -t bl3x -c $< $@
 
-$(BUILDDIR)/fip/gxl/bl31.bin.enc: fip $(PROG)
+$(BUILDDIR)/fip/gxl/bl31.bin.enc: fip $(PROG) $(ATF)
+ifdef ATF
+	./$(PROG) -t bl3x -c "$(ATF)" $@
+else
 	./$(PROG) -t bl3x -c $(BUILDDIR)/fip/gxl/bl31.img $@
+endif
 
 $(BUILDDIR)/fip/gxl/u-boot.bin.enc: $(PROG) $(UBOOT)
 ifdef UBOOT


### PR DESCRIPTION
It's possible to run mainline ATF on some amlogic board, for instance
libretch potato board. Currently, the code is always using vendor
ATF. This change is allowing to specify an alternate path to the
ATF binary.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>