### PR TITLE
Add meson.build to build with Meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('gxlimg', 'c', default_options: ['buildtype=debugoptimized', 'c_std=gnu99'])
+
+deps = [dependency('libssl'), dependency('libcrypto')]
+srcs = ['amlcblk.c', 'amlsblk.c', 'bl2.c', 'bl3.c', 'fip.c', 'main.c']
+
+add_project_arguments('-D_GNU_SOURCE', language: 'c')
+
+if get_option('buildtype') == 'debug'
+    add_project_arguments('-DDEBUG=1', language: 'c')
+endif
+
+executable('gxlimg', srcs, dependencies : deps)


### PR DESCRIPTION
Ironic isn't it ?

While I also love gool ol' makefiles, Meson is very powerful, modern and is able to set very good compiler flags, and bonus, make integration with build systems (yocto, buildroot, snaps, ...) as easy as with autotools but without the hassle.