### PR TITLE
Update filenames in DDR firmware extraction process

### DIFF
--- a/fip.c
+++ b/fip.c
@@ -895,7 +895,7 @@ static int gi_fip_ddrfw_add(struct fip *fip, int fdout, int fdin,
 	/* Align size on 16k */
 	entry.size = ((sz - 0x60) + 0x3fff) & 0xffffc000;
 
-	off = lseek(fdin, 0x20, SEEK_SET);
+	off = lseek(fdin, SHA2_SZ, SEEK_SET);
 	if(off < 0) {
 		SEEK_ERR(off, ret);
 		goto out;


### PR DESCRIPTION
The goal of this is to make it easier to compare the firmware blobs from various bootloader binaries as well as with the files from https://github.com/LibreELEC/amlogic-boot-fip