### PR TITLE
Fix non-zero return code of gi_fip_extract_bl3x after success extraction

### DIFF
--- a/fip.c
+++ b/fip.c
@@ -1637,6 +1637,7 @@ static int gi_fip_extract_bl3x(struct fip_toc_info const *toc, int fdin,
 		close(binfd);
 		binfd=-1;
 	}
+	ret = 0;
 
 out:
 	if(binfd >= 0)


### PR DESCRIPTION
The ret would record the result of the last snprintf call, whether it was successfull or not. Thus it would return a positive number marking failure even after a successful extraction. And as that would be reported as the program's return code, users would be confused on whether the extraction was really failed.

Setting ret to 0 before returning to correctly reflect the result.