### PR TITLE
Fix non-zero return code of gi_fip_extract_ddrfw after success extrac…

### DIFF
--- a/fip.c
+++ b/fip.c
@@ -1559,6 +1559,7 @@ static int gi_fip_extract_ddrfw(int fd, char const *dir, int bl2sz)
 		close(ddr_fw_fd);
 		ddr_fw_fd = -1;
 	}
+	ret = 0;
 
 out:
 	if(ddr_fw_fd >= 0)


### PR DESCRIPTION
when using gxlimg to unpack the g12b FIP, it returns a non-zero value even if successful, causing a shell error