### PR TITLE
Add a new build option which allows creating reproducible output if S…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ ifeq ($(DEBUG), 1)
 	CFLAGS += -DDEBUG=1 -g -O0
 endif
 
+ifeq ($(REPRODUCIBLE), 1)
+	CFLAGS += -DREPRODUCIBLE=1
+endif
+
 define rm-file
 	@(rm $(1) 2>/dev/null && \
 		echo "rm $(1)") || true

--- a/bl2.c
+++ b/bl2.c
@@ -138,6 +138,17 @@ static int gi_bl2_dump_hdr(struct bl2 const *bl2, int fd)
 	ret = gi_random(rd, BL2IV_SZ);
 	if(ret < 0)
 		goto out;
+#ifdef REPRODUCIBLE
+	/* If SOURCE_DATE_EPOCH is set, replace the random IV with a reproducible
+	   string */
+	if (getenv("SOURCE_DATE_EPOCH")) {
+		memset(rd, 0, BL2IV_SZ);
+		/* SOURCE_DATE_EPOCH is a UNIX epoch in base-10 and is currently 10
+		   chars long. It will no longer fit here after 2286-11-20T17:46:40 UTC
+		 */
+		snprintf((char *)rd, BL2IV_SZ, "SDE=%s\n", getenv("SOURCE_DATE_EPOCH"));
+	}
+#endif
 
 	off = lseek(fd, 0, SEEK_SET);
 	if(off < 0) {

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('gxlimg', 'c', default_options: ['buildtype=debugoptimized', 'c_std=gnu99'])
+project('gxlimg', 'c', default_options: ['buildtype=debugoptimized', 'c_std=gnu99'], meson_version : '>= 1.1')
 
 deps = [dependency('libssl'), dependency('libcrypto')]
 srcs = ['amlcblk.c', 'amlsblk.c', 'bl2.c', 'bl3.c', 'fip.c', 'main.c']
@@ -7,6 +7,10 @@ add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
 if get_option('buildtype') == 'debug'
     add_project_arguments('-DDEBUG=1', language: 'c')
+endif
+
+if get_option('reproducible')
+    add_project_arguments('-DREPRODUCIBLE=1', language: 'c')
 endif
 
 executable('gxlimg', srcs, dependencies : deps, install : true)

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('reproducible', type : 'boolean', value : false, description : 'Use SOURCE_DATE_EPOCH environment variable to produce reproducible output')


### PR DESCRIPTION
…OURCE_DATE_EPOCH is set

If gxlimage is compiled with make REPRODUCIBLE=1 or with -Dreproducible=true and if SOURCE_DATE_EPOCH is set at runtime, then the created image will be bit-by-bit reproducible for the same versions of SOURCE_DATE_EPOCH. This replaces 16 bytes which were filled with values from /dev/random with a string derived from the SOURCE_DATE_EPOCH value.